### PR TITLE
N°8835 - Add Spanish translation (es_cr) for itop-assign-to-me

### DIFF
--- a/es_cr.dict.itop-assign-to-me.php
+++ b/es_cr.dict.itop-assign-to-me.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Localized data
+ *
+ * @copyright   Copyright (C) 2013 XXXXX
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+Dict::Add('ES CR', 'Spanish', 'Español, Castellano', array(
+	'Menu:AssignToMe' => 'Asignar a mi',
+	'Menu:AssignToMe+' => 'Asignar este ticket a mi',
+));
+


### PR DESCRIPTION
<!--
IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏
Any PRs not following the guidelines or with missing information will not be considered.
-->

## Base information
| Question                                                      | Answer
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Translations

## Objective (enhancement)
Add Spanish (es_CR) dictionary for the **itop-assign-to-me** extension so Spanish-speaking users see the UI strings localized.

**What I changed**
- Added `dictionaries/es_cr.dict.itop-assign-to-me.php`.
- Mirrored all keys from the English dictionary and provided Spanish translations.
- Encoding: UTF-8 (no BOM).

**Why**
- Improves UX for Spanish-speaking users and helps adoption in LATAM environments.

## Proposed solution (enhancement)
- Provide a new dictionary file with the following entries (non-exhaustive example):
  - `UI:Button:AssignToMe` → `Asignar a mi`
  - `UI:Button:AssignToMe+` → `Asignar este ticket a mi`
- File path: `es_cr.dict.itop-assign-to-me.php`
- Example content header:
  ```php
  <?php
  /**
   * Localized data
   * @license http://opensource.org/licenses/AGPL-3.0
   */
 Dict::Add('ES CR', 'Spanish', 'Español, Castellano', array(
	'Menu:AssignToMe' => 'Asignar a mi',
	'Menu:AssignToMe+' => 'Asignar este ticket a mi',
));
