### PR TITLE
N°9964 - Update german translations (iTop 3.3)

### DIFF
--- a/dictionaries/de.dict.itop-assign-to-me.php
+++ b/dictionaries/de.dict.itop-assign-to-me.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Localized data
+ *
+ * @copyright   Copyright (C) 2013-2026 XXXXX
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+Dict::Add('DE DE', 'German', 'Deutsch', array(
+	'Menu:AssignToMe' => 'Mir zuweisen',
+	'Menu:AssignToMe+' => 'Dieses Ticket mir selbst zuweisen',
+));


### PR DESCRIPTION
The module ships dictionaries for other languages but none for German, so
German users fall back to English throughout. This pull request adds it.

English source strings and dictionary keys are untouched; only German values
change. Each printf placeholder was checked against its English entry.